### PR TITLE
Track DAO Council + Treasury Management multisigs; flag disputed committee wallets

### DIFF
--- a/src/entities/Wallets.ts
+++ b/src/entities/Wallets.ts
@@ -45,9 +45,15 @@ export const WALLETS: Wallet[] = [
     network: Networks.getEth(),
     status: WalletStatus.ACTIVE,
   },
-  // DAO Treasury Management Multisig. Funded from the Aragon Agent to perform
-  // treasury / DeFi operations (e.g. staking ETH, trading MANA, depositing
-  // stablecoins into DeFi vaults).
+  // DAO Treasury Management Multisig. A classic (Safe) multisig used as a
+  // modern alternative to the Aragon Agent for treasury / DeFi operations
+  // (e.g. staking ETH, trading MANA, depositing stablecoins into DeFi vaults),
+  // which are impractical through the Aragon finance app. Funded from the
+  // Aragon Agent and managed by a group defined by the DAO Council per:
+  //   - "Approval of Decentraland Treasury Mandate"
+  //     https://snapshot.org/#/s:daocouncil.dcl.eth/proposal/0x4180bc3bd1669224a425a625dfa61e06610b7c205d3e9151e81ae40f64cfee33
+  //   - "Treasury Withdrawal to Operational Multisig for DAO Operations and Capital Deployment to Avantgarde"
+  //     https://snapshot.org/#/s:daocouncil.dcl.eth/proposal/0x866e65525317e6dda4913533e279989dee28e8c033acf705b54a843d813a545a
   // NOTE: balances only cover the fixed token list in entities/Tokens.ts
   // (MANA, ETH, MATIC, DAI, USDT, USDC, WETH). DeFi positions held as other
   // tokens — staked ETH (stETH/wstETH/rETH), LP tokens, vault receipt tokens

--- a/src/entities/Wallets.ts
+++ b/src/entities/Wallets.ts
@@ -1,20 +1,64 @@
 import { Networks, Network } from "./Networks"
 
+export enum WalletStatus {
+  // Under DAO control; funds are available to the DAO.
+  ACTIVE = "active",
+  // Controlled by a third party (e.g. the former DAO Committee); funds are
+  // NOT currently available to the DAO.
+  DISPUTED = "disputed",
+}
+
 export type Wallet = {
   name: string
   address: string
   network: Network
+  status: WalletStatus
 }
 
 enum WalletNames {
   ARAGON = "Aragon Agent",
   DAO = "DAO Committee",
+  COUNCIL = "DAO Council Operational Multisig",
 }
 
+// Proposal that deprecated the DAO Committee and created the Council
+// Operational Multisig. Surfaced in the UI as the "Learn more" reference.
+export const COMMITTEE_DEPRECATION_PROPOSAL_ID = "bb2b8234-42aa-4ca2-a049-3c7355d4caa4"
+
 export const WALLETS: Wallet[] = [
-  { name: WalletNames.ARAGON, address: "0x9a6ebe7e2a7722f8200d0ffb63a1f6406a0d7dce", network: Networks.getEth() },
-  { name: WalletNames.DAO, address: "0x89214c8ca9a49e60a3bfa8e00544f384c93719b1", network: Networks.getEth() },
-  { name: WalletNames.DAO, address: "0xb08e3e7cc815213304d884c88ca476ebc50eaab2", network: Networks.getPolygon() },
+  {
+    name: WalletNames.ARAGON,
+    address: "0x9a6ebe7e2a7722f8200d0ffb63a1f6406a0d7dce",
+    network: Networks.getEth(),
+    status: WalletStatus.ACTIVE,
+  },
+  // DAO Council Operational Multisig (3-of-5). Replaces the deprecated DAO
+  // Committee per proposal bb2b8234. Deployed on Ethereum; a Polygon
+  // deployment is expected. Balances are scanned on BOTH networks for every
+  // address (see export-balances.ts), so a same-address Polygon Safe will be
+  // tracked automatically once deployed. If the Polygon Safe is deployed to a
+  // DIFFERENT address, add a second entry here for that address.
+  {
+    name: WalletNames.COUNCIL,
+    address: "0x184e4d9a26add0af1eafc145550e890a421f16d7",
+    network: Networks.getEth(),
+    status: WalletStatus.ACTIVE,
+  },
+  // The former DAO Committee multisigs remain controlled by the deprecated
+  // committee, which has not returned the assets to the DAO. Flagged as
+  // disputed so the transparency UI can warn that these funds are withheld.
+  {
+    name: WalletNames.DAO,
+    address: "0x89214c8ca9a49e60a3bfa8e00544f384c93719b1",
+    network: Networks.getEth(),
+    status: WalletStatus.DISPUTED,
+  },
+  {
+    name: WalletNames.DAO,
+    address: "0xb08e3e7cc815213304d884c88ca476ebc50eaab2",
+    network: Networks.getPolygon(),
+    status: WalletStatus.DISPUTED,
+  },
 ]
 
 export class Wallets {

--- a/src/entities/Wallets.ts
+++ b/src/entities/Wallets.ts
@@ -19,6 +19,7 @@ enum WalletNames {
   ARAGON = "Aragon Agent",
   DAO = "DAO Committee",
   COUNCIL = "DAO Council Operational Multisig",
+  TREASURY_MANAGEMENT = "DAO Treasury Management Multisig",
 }
 
 // Proposal that deprecated the DAO Committee and created the Council
@@ -41,6 +42,21 @@ export const WALLETS: Wallet[] = [
   {
     name: WalletNames.COUNCIL,
     address: "0x184e4d9a26add0af1eafc145550e890a421f16d7",
+    network: Networks.getEth(),
+    status: WalletStatus.ACTIVE,
+  },
+  // DAO Treasury Management Multisig. Funded from the Aragon Agent to perform
+  // treasury / DeFi operations (e.g. staking ETH, trading MANA, depositing
+  // stablecoins into DeFi vaults).
+  // NOTE: balances only cover the fixed token list in entities/Tokens.ts
+  // (MANA, ETH, MATIC, DAI, USDT, USDC, WETH). DeFi positions held as other
+  // tokens — staked ETH (stETH/wstETH/rETH), LP tokens, vault receipt tokens
+  // (aTokens, yVault shares, etc.) — are NOT yet captured, so funds deployed
+  // into protocols will under-report here. Tracking those needs a follow-up
+  // (extend TOKENS or integrate a portfolio API such as DeBank/Zapper/Zerion).
+  {
+    name: WalletNames.TREASURY_MANAGEMENT,
+    address: "0x96e2f6099860731cfdc0af700de862cf6eba4407",
     network: Networks.getEth(),
     status: WalletStatus.ACTIVE,
   },

--- a/src/entities/Wallets.ts
+++ b/src/entities/Wallets.ts
@@ -45,21 +45,9 @@ export const WALLETS: Wallet[] = [
     network: Networks.getEth(),
     status: WalletStatus.ACTIVE,
   },
-  // DAO Treasury Management Multisig. A classic (Safe) multisig used as a
-  // modern alternative to the Aragon Agent for treasury / DeFi operations
-  // (e.g. staking ETH, trading MANA, depositing stablecoins into DeFi vaults),
-  // which are impractical through the Aragon finance app. Funded from the
-  // Aragon Agent and managed by a group defined by the DAO Council per:
-  //   - "Approval of Decentraland Treasury Mandate"
-  //     https://snapshot.org/#/s:daocouncil.dcl.eth/proposal/0x4180bc3bd1669224a425a625dfa61e06610b7c205d3e9151e81ae40f64cfee33
-  //   - "Treasury Withdrawal to Operational Multisig for DAO Operations and Capital Deployment to Avantgarde"
-  //     https://snapshot.org/#/s:daocouncil.dcl.eth/proposal/0x866e65525317e6dda4913533e279989dee28e8c033acf705b54a843d813a545a
-  // NOTE: balances only cover the fixed token list in entities/Tokens.ts
-  // (MANA, ETH, MATIC, DAI, USDT, USDC, WETH). DeFi positions held as other
-  // tokens — staked ETH (stETH/wstETH/rETH), LP tokens, vault receipt tokens
-  // (aTokens, yVault shares, etc.) — are NOT yet captured, so funds deployed
-  // into protocols will under-report here. Tracking those needs a follow-up
-  // (extend TOKENS or integrate a portfolio API such as DeBank/Zapper/Zerion).
+  // DAO Treasury Management Multisig. Funded from the Aragon Agent to perform
+  // treasury / DeFi operations (e.g. staking ETH, trading MANA, depositing
+  // stablecoins into DeFi vaults).
   {
     name: WalletNames.TREASURY_MANAGEMENT,
     address: "0x96e2f6099860731cfdc0af700de862cf6eba4407",

--- a/src/export-balances.ts
+++ b/src/export-balances.ts
@@ -111,6 +111,7 @@ async function main() {
           symbol: tokenValue.symbol,
           network: NetworkName.ETHEREUM,
           address: wallet.address,
+          status: wallet.status,
           contractAddress: tokenValue.contractAddress,
           decimals: tokenValue.decimals
         })
@@ -128,6 +129,7 @@ async function main() {
           symbol: tokenValue.symbol,
           network: NetworkName.POLYGON,
           address: wallet.address,
+          status: wallet.status,
           contractAddress: tokenValue.contractAddress,
           decimals: tokenValue.decimals
         })
@@ -147,6 +149,7 @@ async function main() {
     { id: 'rate', title: 'USD Rate' },
     { id: 'network', title: 'Network' },
     { id: 'address', title: 'Address' },
+    { id: 'status', title: 'Status' },
     { id: 'contractAddress', title: 'Token' }
   ])
 }


### PR DESCRIPTION
## Summary

Adds **wallet status tracking** to the balances pipeline and registers two new DAO wallets:

1. **DAO Council Operational Multisig** (`0x184e…16d7`, ETH) — replaces the deprecated DAO Committee.
2. **DAO Treasury Management Multisig** (`0x96e2…4407`, ETH) — funded from the Aragon Agent for treasury/DeFi operations.

It also flags the former **DAO Committee** wallets, whose funds are not currently under DAO control.

Refs proposal [DAO Committee Deprecation & Replacement](https://decentraland.org/governance/proposal/?id=bb2b8234-42aa-4ca2-a049-3c7355d4caa4).

## Changes

- **`entities/Wallets.ts`**
  - New `WalletStatus` enum (`active` | `disputed`) on the `Wallet` model.
  - Adds the **Council Operational Multisig** (`0x184e…16d7`, active).
  - Adds the **Treasury Management Multisig** (`0x96e2…4407`, active).
  - Flags both former **DAO Committee** multisigs (ETH + Polygon) as `disputed`.
- **`export-balances.ts`** — propagates `status` into `balances.json` / `balances.csv`.

## ⚠️ Known limitation — DeFi positions not yet tracked

Balances only cover the fixed token list in `entities/Tokens.ts` (MANA, ETH, MATIC, DAI, USDT, USDC, WETH). The Treasury Management wallet is meant to deploy funds into DeFi, where holdings become **untracked** tokens — staked ETH (stETH/wstETH/rETH), LP tokens, vault receipt tokens (aTokens, yVault shares). Those positions will **under-report** here until a follow-up extends `TOKENS` or integrates a portfolio API (DeBank/Zapper/Zerion). Documented inline.

## Polygon note

Balances are scanned on **both** networks for every tracked address, so a **same-address** Polygon Safe will be picked up **automatically** once deployed. If deployed to a *different* address, add a second entry in `Wallets.ts` (documented inline).

## Rollout — merge this first

⚠️ **Merge before the UI PR.** The companion UI change is backward-compatible and only renders the new wallets / disputed warnings once this pipeline publishes the updated `balances.json` (daily job or manual run).

**Companion UI PR:** decentraland/governance-ui#250

## Testing notes

- Couldn't run the pipeline locally (needs Alchemy/CoinGecko keys); new balances appear when the scheduled job runs with real credentials.
- Change is additive and type-consistent; CI/ts-jest will typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)