### PR TITLE
Exclude internal DAO wallet transfers from expense reporting

### DIFF
--- a/src/export-api-v2.ts
+++ b/src/export-api-v2.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs'
+import { Wallets } from './entities/Wallets'
 type FetchResponse = Response
 /** CONFIG / CONSTANTS */
 const DCL_SUBGRAPH_API_KEY = process.env.DCL_SUBGRAPH_API_KEY
@@ -49,6 +50,12 @@ const DAO_TREASURY_ETH = [
 const DAO_TREASURY_POLYGON = [
   '0xb08e3e7cc815213304d884c88ca476ebc50eaab2' // DAO  (Polygon)
 ].map((a) => a.toLowerCase())
+
+// Every DAO-controlled wallet (single source of truth: entities/Wallets).
+// Transfers BETWEEN these wallets are internal treasury movements (e.g. funding
+// a new multisig from the Aragon Agent), not real expenses, so they must be
+// excluded from the "Other expenses" total.
+const DAO_WALLET_SET = new Set(Wallets.getAddresses().map((a) => a.toLowerCase()))
 
 // // Payment addresses
 const CURATORS_PAYMENT_ADDRESSES = [
@@ -1195,7 +1202,10 @@ async function calcOtherExpensesUSD(
 
     if (!amount || !asset || !toAddrLower) continue
 
-  
+    // Skip internal movements between DAO wallets (e.g. Aragon Agent funding a
+    // new multisig). These are not expenses, just treasury reallocations.
+    if (DAO_WALLET_SET.has(toAddrLower)) continue
+
     if (CURATORS_PAYMENT_SET.has(toAddrLower)) continue
     if (DAO_COMMITTEE_PAYMENT_SET.has(toAddrLower)) continue
     if (DAO_COUNCIL_PAYMENT_SET.has(toAddrLower)) continue


### PR DESCRIPTION
## Summary

Internal treasury movements between DAO wallets were being counted as **expenses** in the income/expenses section of the transparency page. As of today this inflated the "Other expenses" figure to **~\$1,638,962** — driven entirely by the **Aragon Agent** funding the newly tracked **Council Operational** (`0x184e…16d7`) and **Treasury Management** (`0x96e2…4407`) multisigs (added in #121). Moving funds from one DAO wallet to another is not spending.

## Root cause

`calcOtherExpensesUSD` in `src/export-api-v2.ts` queries every transfer **out of** a DAO treasury address and books it as an expense, excluding only the committee/council/curator **payout recipient** sets. It never excluded transfers **to other DAO wallets**, so wallet-to-wallet reallocations counted as real outflows.

(Note: `transactions.json` / `api.json` already handle this correctly — they tag a transfer `INTERNAL` when both ends are tracked wallets. Only the `api-v2.json` expense path was missing the check.)

## Change

- Import `Wallets` and build `DAO_WALLET_SET` from `Wallets.getAddresses()` — a single source of truth, so any wallet added to `entities/Wallets.ts` is automatically treated as internal.
- In `calcOtherExpensesUSD`, skip any transfer whose recipient is in `DAO_WALLET_SET`.

```ts
// Skip internal movements between DAO wallets (e.g. Aragon Agent funding a
// new multisig). These are not expenses, just treasury reallocations.
if (DAO_WALLET_SET.has(toAddrLower)) continue
```

## Effect

`main` already includes the Council and Treasury Management addresses (merged in #121), so once the daily job regenerates `api-v2.json`, the ~\$1.6M of internal movements drops out of "Other expenses". No dependency on any other PR.

## Testing notes

- Couldn't run the pipeline locally (needs Alchemy/CoinGecko keys); corrected figures appear when the scheduled job runs with real credentials.
- Change is additive and type-consistent; the import mirrors the existing pattern in `export-transactions.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)